### PR TITLE
[REFACTOR] 소셜 로그아웃 방식 변경, 리프레시 토큰 갱신 추가

### DIFF
--- a/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.net.URI;
 
-@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class AuthController {
@@ -67,9 +65,7 @@ public class AuthController {
     @GetMapping("/api/v1/oauth2/logout")
     public ResponseEntity<Void> oauthLogout(@LoginUser LoginInfo loginInfo,
                                             HttpServletRequest request, HttpServletResponse response) {
-        log.info("로그아웃 시작");
         authService.logout(loginInfo.memberId());
-        log.info("로그아웃 끝");
 
         request.getSession().removeAttribute(LOGIN_ATTRIBUTE_NAME);
 

--- a/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
@@ -85,6 +85,8 @@ public class AuthController {
         Cookie cookie = authService.expireCookie();
         response.addCookie(cookie);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                .location(URI.create(HOME))
+                .build();
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kau/capstone/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.net.URI;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class AuthController {
@@ -65,7 +67,9 @@ public class AuthController {
     @GetMapping("/api/v1/oauth2/logout")
     public ResponseEntity<Void> oauthLogout(@LoginUser LoginInfo loginInfo,
                                             HttpServletRequest request, HttpServletResponse response) {
+        log.info("로그아웃 시작");
         authService.logout(loginInfo.memberId());
+        log.info("로그아웃 끝");
 
         request.getSession().removeAttribute(LOGIN_ATTRIBUTE_NAME);
 

--- a/src/main/java/com/kau/capstone/domain/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/KakaoUserInfoResponse.java
@@ -7,14 +7,6 @@ public record KakaoUserInfoResponse(
         String id,
         @JsonProperty("kakao_account") KakaoAccount account
 ) {
-    public UserInfoDto toUserInfo(String refreshToken) {
-        return UserInfoDto.builder()
-                .id(id)
-                .nickname(account.profile.nickname)
-                .email(account.email)
-                .refreshToken(refreshToken)
-                .build();
-    }
 
     public record KakaoAccount(
             KakaoProfile profile,

--- a/src/main/java/com/kau/capstone/domain/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/KakaoUserInfoResponse.java
@@ -7,11 +7,12 @@ public record KakaoUserInfoResponse(
         String id,
         @JsonProperty("kakao_account") KakaoAccount account
 ) {
-    public UserInfoDto toUserInfo() {
+    public UserInfoDto toUserInfo(String refreshToken) {
         return UserInfoDto.builder()
                 .id(id)
                 .nickname(account.profile.nickname)
                 .email(account.email)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/kau/capstone/domain/auth/dto/NaverUserInfoResponse.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/NaverUserInfoResponse.java
@@ -6,14 +6,6 @@ public record NaverUserInfoResponse(
         @JsonProperty("response") NaverAccount account
 ) {
 
-    public UserInfoDto toUserInfo() {
-        return UserInfoDto.builder()
-                .id(account.id)
-                .nickname(account.name)
-                .email(account.email)
-                .build();
-    }
-
     public record NaverAccount(
             String id,
             String name,

--- a/src/main/java/com/kau/capstone/domain/auth/dto/TokenInfo.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/TokenInfo.java
@@ -3,20 +3,20 @@ package com.kau.capstone.domain.auth.dto;
 import lombok.Builder;
 
 @Builder
-public record TokenResponse (
+public record TokenInfo(
     String accessToken,
     String refreshToken
 ) {
 
-    public static TokenResponse toResponse(KakaoAccessTokenResponse response) {
-        return TokenResponse.builder()
+    public static TokenInfo toResponse(KakaoAccessTokenResponse response) {
+        return TokenInfo.builder()
                 .accessToken(response.accessToken())
                 .refreshToken(response.refreshToken())
                 .build();
     }
 
-    public static TokenResponse toResponse(NaverAccessTokenResponse response) {
-        return TokenResponse.builder()
+    public static TokenInfo toResponse(NaverAccessTokenResponse response) {
+        return TokenInfo.builder()
                 .accessToken(response.accessToken())
                 .refreshToken(response.refreshToken())
                 .build();

--- a/src/main/java/com/kau/capstone/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,24 @@
+package com.kau.capstone.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse (
+    String accessToken,
+    String refreshToken
+) {
+
+    public static TokenResponse toResponse(KakaoAccessTokenResponse response) {
+        return TokenResponse.builder()
+                .accessToken(response.accessToken())
+                .refreshToken(response.refreshToken())
+                .build();
+    }
+
+    public static TokenResponse toResponse(NaverAccessTokenResponse response) {
+        return TokenResponse.builder()
+                .accessToken(response.accessToken())
+                .refreshToken(response.refreshToken())
+                .build();
+    }
+}

--- a/src/main/java/com/kau/capstone/domain/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/UserInfoDto.java
@@ -18,4 +18,13 @@ public record UserInfoDto(
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    public static UserInfoDto toDto(NaverUserInfoResponse response, String refreshToken) {
+        return UserInfoDto.builder()
+                .id(response.account().id())
+                .nickname(response.account().name())
+                .email(response.account().email())
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/kau/capstone/domain/auth/dto/UserInfoDto.java
@@ -6,6 +6,16 @@ import lombok.Builder;
 public record UserInfoDto(
         String id,
         String nickname,
-        String email
+        String email,
+        String refreshToken
 ) {
+
+    public static UserInfoDto toDto(KakaoUserInfoResponse response, String refreshToken) {
+        return UserInfoDto.builder()
+                .id(response.id())
+                .nickname(response.account().profile().nickname())
+                .email(response.account().email())
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kau/capstone/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.kau.capstone.domain.auth.service;
 
 import com.kau.capstone.domain.auth.dto.SignUserDto;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.OAuthProvider;
@@ -49,6 +50,9 @@ public class AuthService {
         Member member = memberService.findById(memberId);
         SocialSite socialSite = SocialSite.findBySocialSite(member.getSocialSite());
         OAuthProvider oAuthProvider = oAuthProviders.getClient(socialSite);
-        oAuthProvider.logout(member.getPlatformId());
+
+        TokenInfo tokenInfo = oAuthProvider.updateToken(member.getRefreshToken());
+        memberService.updateRefreshToken(memberId, tokenInfo.refreshToken());
+        oAuthProvider.logout(tokenInfo.accessToken());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kau/capstone/domain/auth/service/AuthService.java
@@ -12,6 +12,8 @@ import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -52,7 +54,10 @@ public class AuthService {
         OAuthProvider oAuthProvider = oAuthProviders.getClient(socialSite);
 
         TokenInfo tokenInfo = oAuthProvider.updateToken(member.getRefreshToken());
-        memberService.updateRefreshToken(memberId, tokenInfo.refreshToken());
+        Optional<String> refreshToken = Optional.ofNullable(tokenInfo.refreshToken());
+        if (refreshToken.isPresent()) {
+            memberService.updateRefreshToken(memberId, tokenInfo.refreshToken());
+        }
         oAuthProvider.logout(tokenInfo.accessToken());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
@@ -1,6 +1,6 @@
 package com.kau.capstone.domain.auth.util.provider;
 
-import com.kau.capstone.domain.auth.dto.TokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.access.KakaoAccessToken;
@@ -36,7 +36,7 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public TokenResponse updateToken(String beforeRefreshToken) {
+    public TokenInfo updateToken(String beforeRefreshToken) {
         return refreshToken.updateToken(beforeRefreshToken);
     }
 

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
@@ -41,8 +41,8 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public void logout(String platformId) {
-        logout.logout(platformId);
+    public void logout(String accessToken) {
+        logout.logout(accessToken);
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/KakaoProvider.java
@@ -1,10 +1,12 @@
 package com.kau.capstone.domain.auth.util.provider;
 
+import com.kau.capstone.domain.auth.dto.TokenResponse;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.access.KakaoAccessToken;
 import com.kau.capstone.domain.auth.util.provider.logout.KakaoLogout;
 import com.kau.capstone.domain.auth.util.provider.redirect.KakaoRedirect;
+import com.kau.capstone.domain.auth.util.provider.refresh.KakaoRefreshToken;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,11 +14,14 @@ public class KakaoProvider implements OAuthProvider {
 
     private final KakaoRedirect redirect;
     private final KakaoAccessToken accessToken;
+    private final KakaoRefreshToken refreshToken;
     private final KakaoLogout logout;
 
-    public KakaoProvider(KakaoRedirect redirect, KakaoAccessToken accessToken, KakaoLogout logout) {
+    public KakaoProvider(KakaoRedirect redirect, KakaoAccessToken accessToken, KakaoRefreshToken refreshToken,
+                         KakaoLogout logout) {
         this.redirect = redirect;
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
         this.logout = logout;
     }
 
@@ -28,6 +33,11 @@ public class KakaoProvider implements OAuthProvider {
     @Override
     public UserInfoDto getUserInfo(String code) {
         return accessToken.getPlatformUser(code);
+    }
+
+    @Override
+    public TokenResponse updateToken(String beforeRefreshToken) {
+        return refreshToken.updateToken(beforeRefreshToken);
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
@@ -1,5 +1,6 @@
 package com.kau.capstone.domain.auth.util.provider;
 
+import com.kau.capstone.domain.auth.dto.TokenResponse;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.access.NaverAccessToken;
@@ -28,6 +29,11 @@ public class NaverProvider implements OAuthProvider {
     @Override
     public UserInfoDto getUserInfo(String code) {
         return accessToken.getPlatformUser(code);
+    }
+
+    @Override
+    public TokenResponse updateToken(String beforeRefreshToken) {
+        return TokenResponse.builder().build();
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
@@ -6,6 +6,7 @@ import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.access.NaverAccessToken;
 import com.kau.capstone.domain.auth.util.provider.logout.NaverLogout;
 import com.kau.capstone.domain.auth.util.provider.redirect.NaverRedirect;
+import com.kau.capstone.domain.auth.util.provider.refresh.NaverRefreshToken;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,11 +14,14 @@ public class NaverProvider implements OAuthProvider {
 
     private final NaverRedirect redirect;
     private final NaverAccessToken accessToken;
+    private final NaverRefreshToken refreshToken;
     private final NaverLogout naverLogout;
 
-    public NaverProvider(NaverRedirect redirect, NaverAccessToken accessToken, NaverLogout naverLogout) {
+    public NaverProvider(NaverRedirect redirect, NaverAccessToken accessToken, NaverRefreshToken refreshToken,
+                         NaverLogout naverLogout) {
         this.redirect = redirect;
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
         this.naverLogout = naverLogout;
     }
 
@@ -33,7 +37,7 @@ public class NaverProvider implements OAuthProvider {
 
     @Override
     public TokenInfo updateToken(String beforeRefreshToken) {
-        return TokenInfo.builder().build();
+        return refreshToken.updateToken(beforeRefreshToken);
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
@@ -37,8 +37,8 @@ public class NaverProvider implements OAuthProvider {
     }
 
     @Override
-    public void logout(String refreshToken) {
-        naverLogout.logout(refreshToken);
+    public void logout(String accessToken) {
+        naverLogout.logout(accessToken);
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/NaverProvider.java
@@ -1,6 +1,6 @@
 package com.kau.capstone.domain.auth.util.provider;
 
-import com.kau.capstone.domain.auth.dto.TokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 import com.kau.capstone.domain.auth.util.provider.access.NaverAccessToken;
@@ -32,8 +32,8 @@ public class NaverProvider implements OAuthProvider {
     }
 
     @Override
-    public TokenResponse updateToken(String beforeRefreshToken) {
-        return TokenResponse.builder().build();
+    public TokenInfo updateToken(String beforeRefreshToken) {
+        return TokenInfo.builder().build();
     }
 
     @Override

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
@@ -1,5 +1,6 @@
 package com.kau.capstone.domain.auth.util.provider;
 
+import com.kau.capstone.domain.auth.dto.TokenResponse;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 
@@ -8,6 +9,8 @@ public interface OAuthProvider {
     String getRedirectURL();
 
     UserInfoDto getUserInfo(String code);
+
+    TokenResponse updateToken(String beforeRefreshToken);
 
     void logout(String platformId);
 

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
@@ -1,6 +1,6 @@
 package com.kau.capstone.domain.auth.util.provider;
 
-import com.kau.capstone.domain.auth.dto.TokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.SocialSite;
 
@@ -10,7 +10,7 @@ public interface OAuthProvider {
 
     UserInfoDto getUserInfo(String code);
 
-    TokenResponse updateToken(String beforeRefreshToken);
+    TokenInfo updateToken(String beforeRefreshToken);
 
     void logout(String platformId);
 

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/OAuthProvider.java
@@ -12,7 +12,7 @@ public interface OAuthProvider {
 
     TokenInfo updateToken(String beforeRefreshToken);
 
-    void logout(String platformId);
+    void logout(String refreshToken);
 
     SocialSite getSocialSite();
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/access/KakaoAccessToken.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/access/KakaoAccessToken.java
@@ -2,6 +2,7 @@ package com.kau.capstone.domain.auth.util.provider.access;
 
 import com.kau.capstone.domain.auth.dto.KakaoAccessTokenResponse;
 import com.kau.capstone.domain.auth.dto.KakaoUserInfoResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.provider.secret.KakaoSecretValue;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -33,11 +34,11 @@ public class KakaoAccessToken {
     }
 
     public UserInfoDto getPlatformUser(String code) {
-        String accessToken = requestAccessToken(code);
-        return getUserInfo(accessToken);
+        TokenInfo tokenInfo = requestAccessToken(code);
+        return getUserInfo(tokenInfo);
     }
 
-    private String requestAccessToken(String code) {
+    private TokenInfo requestAccessToken(String code) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set(GRANT_TYPE, AUTHORIZATION_CODE);
@@ -48,17 +49,17 @@ public class KakaoAccessToken {
         KakaoAccessTokenResponse response = restTemplate.postForEntity(ACCESS_TOKEN_URL, headers,
                 KakaoAccessTokenResponse.class).getBody();
 
-        return response.accessToken();
+        return TokenInfo.toResponse(response);
     }
 
-    private UserInfoDto getUserInfo(String accessToken) {
+    private UserInfoDto getUserInfo(TokenInfo tokenInfo) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.setBearerAuth(accessToken);
+        headers.setBearerAuth(tokenInfo.accessToken());
 
         KakaoUserInfoResponse response = restTemplate.postForEntity(USER_INFO_URL, new HttpEntity<>(headers),
                 KakaoUserInfoResponse.class).getBody();
 
-        return response.toUserInfo();
+        return UserInfoDto.toDto(response, tokenInfo.refreshToken());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/access/NaverAccessToken.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/access/NaverAccessToken.java
@@ -2,6 +2,7 @@ package com.kau.capstone.domain.auth.util.provider.access;
 
 import com.kau.capstone.domain.auth.dto.NaverAccessTokenResponse;
 import com.kau.capstone.domain.auth.dto.NaverUserInfoResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.dto.UserInfoDto;
 import com.kau.capstone.domain.auth.util.provider.secret.NaverSecretValue;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -32,11 +33,11 @@ public class NaverAccessToken {
     }
 
     public UserInfoDto getPlatformUser(String code) {
-        String accessToken = requestAccessToken(code);
-        return getUserInfo(accessToken);
+        TokenInfo tokenInfo = requestAccessToken(code);
+        return getUserInfo(tokenInfo);
     }
 
-    private String requestAccessToken(String code) {
+    private TokenInfo requestAccessToken(String code) {
         HttpHeaders headers = new HttpHeaders();
         headers.set(GRANT_TYPE, AUTHORIZATION_CODE);
         headers.set(CLIENT_ID, secretValue.getClientId());
@@ -47,16 +48,16 @@ public class NaverAccessToken {
         NaverAccessTokenResponse response = restTemplate.postForEntity(ACCESS_TOKEN_URL, headers,
                 NaverAccessTokenResponse.class).getBody();
 
-        return response.accessToken();
+        return TokenInfo.toResponse(response);
     }
 
-    private UserInfoDto getUserInfo(String accessToken) {
+    private UserInfoDto getUserInfo(TokenInfo tokenInfo) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
+        headers.setBearerAuth(tokenInfo.accessToken());
 
         NaverUserInfoResponse response = restTemplate.postForEntity(USER_INFO_URL, new HttpEntity<>(headers),
                 NaverUserInfoResponse.class).getBody();
 
-        return response.toUserInfo();
+        return UserInfoDto.toDto(response, tokenInfo.refreshToken());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/KakaoLogout.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/KakaoLogout.java
@@ -29,15 +29,11 @@ public class KakaoLogout {
         this.secretValue = secretValue;
     }
 
-    public void logout(String platformId) {
+    public void logout(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.add(AUTHORIZATION, KAKAO_AK + secretValue.getAdminKey());
+        headers.setBearerAuth(accessToken);
 
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add(TARGET_ID_TYPE, USER_ID);
-        body.add(TARGET_ID, platformId);
-
-        restTemplate.postForEntity(LOGOUT_URL, new HttpEntity<>(body, headers), String.class);
+        restTemplate.postForEntity(LOGOUT_URL, headers, String.class);
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/KakaoLogout.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/KakaoLogout.java
@@ -1,13 +1,10 @@
 package com.kau.capstone.domain.auth.util.provider.logout;
 
-import com.kau.capstone.domain.auth.util.provider.secret.KakaoSecretValue;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Component
@@ -15,18 +12,10 @@ public class KakaoLogout {
 
     private static final String LOGOUT_URL = "https://kapi.kakao.com/v1/user/logout";
 
-    private static final String AUTHORIZATION = "Authorization";
-    private static final String KAKAO_AK = "KakaoAK ";
-    private static final String TARGET_ID_TYPE = "target_id_type";
-    private static final String USER_ID = "user_id";
-    private static final String TARGET_ID = "target_id";
-
     private final RestTemplate restTemplate;
-    private final KakaoSecretValue secretValue;
 
-    public KakaoLogout(RestTemplateBuilder builder, KakaoSecretValue secretValue) {
-        this.restTemplate = builder.build();
-        this.secretValue = secretValue;
+    public KakaoLogout(RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = restTemplateBuilder.build();
     }
 
     public void logout(String accessToken) {
@@ -34,6 +23,6 @@ public class KakaoLogout {
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setBearerAuth(accessToken);
 
-        restTemplate.postForEntity(LOGOUT_URL, headers, String.class);
+        restTemplate.postForEntity(LOGOUT_URL, new HttpEntity<>(headers), String.class);
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/NaverLogout.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/NaverLogout.java
@@ -16,7 +16,6 @@ public class NaverLogout {
     private static final String LOGOUT_URL = "`https://nid.naver.com/oauth2.0/token";
 
     private static final String DELETE = "delete";
-    private static final String REFRESH_TOKEN = "refresh_token";
 
     private static final String GRANT_TYPE = "grant_type";
     private static final String CLIENT_ID = "client_id";
@@ -33,27 +32,12 @@ public class NaverLogout {
         this.secretValue = secretValue;
     }
 
-    // 카카오와 다르게 네이버는 어드민이 직접 로그아웃이 불가능합니다.
-    // 출처: https://developers.naver.com/docs/login/api/api.md 에서 로그아웃 항목
-    public void logout(String refreshToken) {
-        // String newAccessToken = updateRefreshToken(refreshToken);
-
+    public void logout(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.set(GRANT_TYPE, DELETE);
         headers.set(CLIENT_ID, secretValue.getClientId());
         headers.set(CLIENT_SECRET, secretValue.getClientSecret());
-        headers.set(ACCESS_TOKEN, "newAccessToken");
-        headers.set(SERVICE_PROVIDER, NAVER);
-
-        restTemplate.postForEntity(LOGOUT_URL, headers, String.class);
-    }
-
-    private void updateRefreshToken(String refreshToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(GRANT_TYPE, REFRESH_TOKEN);
-        headers.set(CLIENT_ID, secretValue.getClientId());
-        headers.set(CLIENT_SECRET, secretValue.getClientSecret());
-        headers.set(REFRESH_TOKEN, refreshToken);
+        headers.set(ACCESS_TOKEN, accessToken);
         headers.set(SERVICE_PROVIDER, NAVER);
 
         restTemplate.postForEntity(LOGOUT_URL, headers, String.class);

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/NaverLogout.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/logout/NaverLogout.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class NaverLogout {
 
-    private static final String LOGOUT_URL = "`https://nid.naver.com/oauth2.0/token";
+    private static final String LOGOUT_URL = "https://nid.naver.com/oauth2.0/token";
 
     private static final String DELETE = "delete";
 

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/KakaoRefreshToken.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/KakaoRefreshToken.java
@@ -1,0 +1,40 @@
+package com.kau.capstone.domain.auth.util.provider.refresh;
+
+import com.kau.capstone.domain.auth.dto.KakaoAccessTokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenResponse;
+import com.kau.capstone.domain.auth.util.provider.secret.KakaoSecretValue;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KakaoRefreshToken {
+
+    private static final String UPDATE_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String CLIENT_ID = "client_id";
+
+    private final RestTemplate restTemplate;
+    private final KakaoSecretValue secretValue;
+
+    public KakaoRefreshToken(RestTemplateBuilder restTemplateBuilder, KakaoSecretValue secretValue) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.secretValue = secretValue;
+    }
+
+    public TokenResponse updateToken(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(GRANT_TYPE, REFRESH_TOKEN);
+        headers.set(CLIENT_ID, secretValue.getRestApiKey());
+        headers.set(REFRESH_TOKEN, refreshToken);
+
+        KakaoAccessTokenResponse response = restTemplate.postForEntity(UPDATE_TOKEN_URL, headers,
+                KakaoAccessTokenResponse.class).getBody();
+
+        return TokenResponse.toResponse(response);
+    }
+}

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/KakaoRefreshToken.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/KakaoRefreshToken.java
@@ -1,7 +1,7 @@
 package com.kau.capstone.domain.auth.util.provider.refresh;
 
 import com.kau.capstone.domain.auth.dto.KakaoAccessTokenResponse;
-import com.kau.capstone.domain.auth.dto.TokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
 import com.kau.capstone.domain.auth.util.provider.secret.KakaoSecretValue;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpHeaders;
@@ -25,7 +25,7 @@ public class KakaoRefreshToken {
         this.secretValue = secretValue;
     }
 
-    public TokenResponse updateToken(String refreshToken) {
+    public TokenInfo updateToken(String refreshToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set(GRANT_TYPE, REFRESH_TOKEN);
@@ -35,6 +35,6 @@ public class KakaoRefreshToken {
         KakaoAccessTokenResponse response = restTemplate.postForEntity(UPDATE_TOKEN_URL, headers,
                 KakaoAccessTokenResponse.class).getBody();
 
-        return TokenResponse.toResponse(response);
+        return TokenInfo.toResponse(response);
     }
 }

--- a/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/NaverRefreshToken.java
+++ b/src/main/java/com/kau/capstone/domain/auth/util/provider/refresh/NaverRefreshToken.java
@@ -1,0 +1,42 @@
+package com.kau.capstone.domain.auth.util.provider.refresh;
+
+import com.kau.capstone.domain.auth.dto.KakaoAccessTokenResponse;
+import com.kau.capstone.domain.auth.dto.NaverAccessTokenResponse;
+import com.kau.capstone.domain.auth.dto.TokenInfo;
+import com.kau.capstone.domain.auth.util.provider.secret.NaverSecretValue;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class NaverRefreshToken {
+
+    private static final String UPDATE_TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_SECRET = "client_secret";
+
+    private final RestTemplate restTemplate;
+    private final NaverSecretValue secretValue;
+
+    public NaverRefreshToken(RestTemplateBuilder restTemplateBuilder, NaverSecretValue secretValue) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.secretValue = secretValue;
+    }
+
+    public TokenInfo updateToken(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(GRANT_TYPE, REFRESH_TOKEN);
+        headers.set(CLIENT_ID, secretValue.getClientId());
+        headers.set(CLIENT_SECRET, secretValue.getClientSecret());
+        headers.set(REFRESH_TOKEN, refreshToken);
+
+        NaverAccessTokenResponse response = restTemplate.postForEntity(UPDATE_TOKEN_URL, headers,
+                NaverAccessTokenResponse.class).getBody();
+
+        return TokenInfo.toResponse(response);
+    }
+}

--- a/src/main/java/com/kau/capstone/domain/member/entity/Member.java
+++ b/src/main/java/com/kau/capstone/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
@@ -28,6 +30,9 @@ public class Member extends BaseEntity {
     @Comment("소셜 로그인 사이트")
     private String socialSite;
 
+    @Comment("소셜 사이트 리프레시 토큰값")
+    private String refreshToken;
+
     @Comment("회원 이름")
     private String name;
 
@@ -36,13 +41,4 @@ public class Member extends BaseEntity {
 
     @Comment("회원 포인트")
     private Long point;
-
-    public Member(Long id, String platformId, String socialSite, String name, String email, Long point) {
-        this.id = id;
-        this.platformId = platformId;
-        this.socialSite = socialSite;
-        this.name = name;
-        this.email = email;
-        this.point = point;
-    }
 }

--- a/src/main/java/com/kau/capstone/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kau/capstone/domain/member/repository/MemberRepository.java
@@ -2,10 +2,17 @@ package com.kau.capstone.domain.member.repository;
 
 import com.kau.capstone.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformId(String platformId);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.refreshToken = :refreshToken WHERE m.id = :memberId")
+    void updateRefreshTokenByMemberId(@Param("memberId") Long memberId, @Param("refreshToken") String refreshToken);
 }

--- a/src/main/java/com/kau/capstone/domain/member/service/MemberService.java
+++ b/src/main/java/com/kau/capstone/domain/member/service/MemberService.java
@@ -42,4 +42,9 @@ public class MemberService {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
     }
+
+    @Transactional(propagation = REQUIRES_NEW)
+    public void updateRefreshToken(Long memberId, String refreshToken) {
+        memberRepository.updateRefreshTokenByMemberId(memberId, refreshToken);
+    }
 }

--- a/src/main/java/com/kau/capstone/domain/member/util/MemberMapper.java
+++ b/src/main/java/com/kau/capstone/domain/member/util/MemberMapper.java
@@ -14,6 +14,7 @@ public class MemberMapper {
                 .socialSite(site)
                 .name(userInfoDto.nickname())
                 .email(userInfoDto.email())
+                .refreshToken(userInfoDto.refreshToken())
                 .build();
     }
 }


### PR DESCRIPTION
# 😁 Issue Link

<!-- ❗ merge하면 자동으로 이슈를 닫을 수 있도록 이슈 번호를 적어주세요 -->

- close #23 

# 😆 To Reviewers

<!-- ❗ 리뷰어에게 전달할 내용을 적어주세요 (ex. - 빠른 리뷰 부탁드려요) -->

- 카카오 로그아웃의 경우에는 액세스 토큰 / 어드민 강제 로그아웃 방식이 있지만, 네이버 로그아웃은 액세스 토큰을 통해서만 로그아웃이 가능합니다. 그래서 카카오 로그아웃 로직을 액세스 토큰으로 변경했습니다.
- 유저가 앱을 켜둔 상태에서 나중에 API 요청이 올 수도 있으므로 로그아웃 요청 전에 토큰을 갱신합니다.

소셜 로그인 구성

```mermaid
graph TD;
NaverRedirect-->NaverProvider
NaverAccessToken-->NaverProvider
NaverRefreshToken-->NaverProvider
NaverLogout-->NaverProvider
```

소셜 로그인 동적 매칭

```mermaid
graph TD;
KakaoProvider-->OAuthProviders
NaverProvider-->OAuthProviders
``` 

# 😚 Reference

<!-- ❗ PR에 참고하면 좋은 URL 링크를 적어주세요 -->

- 카카오 로그아웃 문서: [카카오 로그아웃 문서 링크](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#logout)
- 카카오 토큰 갱신 문서: [카카오 토큰 갱신 문서 링크](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#refresh-token)
- 네이버 로그아웃 문서: [네이버 로그아웃 문서 링크](https://developers.naver.com/docs/login/api/api.md#3-2--%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0-%EB%B0%9C%EA%B8%89%EA%B0%B1%EC%8B%A0%EC%82%AD%EC%A0%9C-%EC%9A%94%EC%B2%AD)
- 네이버 토큰 갱신 문서: 로그아웃 문서와 같음

# 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, **코드 수정을 강제하지 말아 주세요.**
* Reviewer 분들은 좋은 코드를 발견한 경우, **칭찬과 격려**를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **7일 이내에 진행**해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  * P1 : **꼭 반영해 주세요** (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  * P2 : 반영을 **적극적으로 고려**해 주시면 좋을 것 같아요 (Comment)
  * P3 : 이런 방법도 있을 것 같아요~ 등의 **사소한 의견**입니다 (Chore) 
