### PR TITLE
fix: 반려동물 정보 조회 api 생성 

### DIFF
--- a/src/main/java/com/kau/capstone/domain/pet/controller/PetRestController.java
+++ b/src/main/java/com/kau/capstone/domain/pet/controller/PetRestController.java
@@ -1,9 +1,13 @@
 package com.kau.capstone.domain.pet.controller;
 
 import com.kau.capstone.domain.pet.dto.request.PetRegistRequest;
+import com.kau.capstone.domain.pet.dto.response.PetInfoResponse;
 import com.kau.capstone.domain.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +24,12 @@ public class PetRestController {
     public ResponseEntity<String> createPetRegist(@RequestBody PetRegistRequest petRegistRequest) {
         petService.registPet(petRegistRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{pet_id}")
+    public ResponseEntity<PetInfoResponse> getPetInfo(@PathVariable Long pet_id) {
+        petService.getPetInfo(pet_id);
+        return new ResponseEntity<>(petService.getPetInfo(pet_id), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/kau/capstone/domain/pet/dto/response/PetInfoResponse.java
+++ b/src/main/java/com/kau/capstone/domain/pet/dto/response/PetInfoResponse.java
@@ -1,0 +1,28 @@
+package com.kau.capstone.domain.pet.dto.response;
+
+import com.kau.capstone.global.common.Gender;
+import com.kau.capstone.global.common.PetType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PetInfoResponse {
+
+    private String name;
+
+    private PetType petType;
+
+    private Gender gender;
+
+    private float weight;
+
+    private String imageUrl;
+
+    private Integer age;
+}

--- a/src/main/java/com/kau/capstone/domain/pet/exception/PetNotFoundException.java
+++ b/src/main/java/com/kau/capstone/domain/pet/exception/PetNotFoundException.java
@@ -1,0 +1,11 @@
+package com.kau.capstone.domain.pet.exception;
+
+import com.kau.capstone.global.exception.ApplicationException;
+import com.kau.capstone.global.exception.ErrorCode;
+
+public class PetNotFoundException extends ApplicationException {
+
+    public PetNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kau/capstone/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/kau/capstone/domain/pet/repository/PetRepository.java
@@ -1,8 +1,10 @@
 package com.kau.capstone.domain.pet.repository;
 
 import com.kau.capstone.domain.pet.entity.Pet;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
+    Optional<Pet> findById(Long id);
 
 }

--- a/src/main/java/com/kau/capstone/domain/pet/service/PetService.java
+++ b/src/main/java/com/kau/capstone/domain/pet/service/PetService.java
@@ -1,8 +1,13 @@
 package com.kau.capstone.domain.pet.service;
 
 import com.kau.capstone.domain.pet.dto.request.PetRegistRequest;
+import com.kau.capstone.domain.pet.dto.response.PetInfoResponse;
+import com.kau.capstone.domain.pet.entity.Pet;
+import com.kau.capstone.domain.pet.exception.PetNotFoundException;
 import com.kau.capstone.domain.pet.repository.PetRepository;
 import com.kau.capstone.domain.pet.util.PetMapper;
+import com.kau.capstone.global.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,5 +23,20 @@ public class PetService {
     @Transactional
     public void registPet(PetRegistRequest petRegistRequest) {
         petRepository.save(PetMapper.toPet(petRegistRequest));
+    }
+
+    public Pet findByPetId(Long petId) {
+        Optional<Pet> petOptional = petRepository.findById(petId);
+
+        // 만약 post 가 존재하지 않으면 ErrorStatus.POST_NOT_FOUND 반환.
+        return petOptional.orElseThrow(
+            () -> new PetNotFoundException(ErrorCode.PET_INFO_NOT_FOUND));
+    }
+
+    public PetInfoResponse getPetInfo(Long petId) {
+
+        Pet pet = findByPetId(petId);
+
+        return PetMapper.toGetResponseDTO(pet);
     }
 }

--- a/src/main/java/com/kau/capstone/domain/pet/util/PetMapper.java
+++ b/src/main/java/com/kau/capstone/domain/pet/util/PetMapper.java
@@ -1,6 +1,7 @@
 package com.kau.capstone.domain.pet.util;
 
 import com.kau.capstone.domain.pet.dto.request.PetRegistRequest;
+import com.kau.capstone.domain.pet.dto.response.PetInfoResponse;
 import com.kau.capstone.domain.pet.entity.Pet;
 import com.kau.capstone.global.common.Gender;
 import com.kau.capstone.global.common.PetType;
@@ -24,4 +25,14 @@ public class PetMapper {
             .build();
     }
 
+    public static PetInfoResponse toGetResponseDTO(Pet pet) {
+        return PetInfoResponse.builder()
+            .age(pet.getAge())
+            .petType(pet.getPetType())
+            .gender(pet.getGender())
+            .name(pet.getName())
+            .weight(pet.getWeight())
+            .imageUrl(pet.getImageUrl())
+            .build();
+    }
 }

--- a/src/main/java/com/kau/capstone/global/exception/ErrorCode.java
+++ b/src/main/java/com/kau/capstone/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "유효하지 않은 성별입니다."),
     LOGIN_MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인 되지 않았거나, 존재하지 않는 유저로 로그인중입니다."),
     SOCIAL_SITE_NOT_SUPPORTED(HttpStatus.NOT_FOUND, "지원하지 않는 소셜 로그인 사이트입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.")
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    PET_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "반려동물 정보를 찾을 수 없습니다.")
     ;//Error Code를 작성한 마지막에 ;를 추가합니다.
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
원래 PR 참조: #16 

코드 복구용

- 브랜치를 복구해서 가져온 뒤, PR을 새로 올려 깃허브상에서 충돌을 수정하려고 했는데, 하드 리셋 후 커밋시 브랜치가 강제로 닫혔습니다 (#32)
- 그래서 브랜치를 새로 만들고, 체리픽으로 필요한 커밋만 가져와서 충돌을 수정했습니다.
