### PR TITLE
Refactor/#216 vaccination entity

### DIFF
--- a/src/main/java/com/kau/capstone/domain/vaccination/dto/OneVaccinationResponse.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/dto/OneVaccinationResponse.java
@@ -1,9 +1,7 @@
 package com.kau.capstone.domain.vaccination.dto;
 
 import com.kau.capstone.domain.vaccination.entity.Vaccination;
-import lombok.Builder;
 
-@Builder
 public record OneVaccinationResponse(
         Long id,
         String name,
@@ -13,12 +11,12 @@ public record OneVaccinationResponse(
 ) {
 
     public static OneVaccinationResponse toResponse(Vaccination vaccination) {
-        return OneVaccinationResponse.builder()
-                .id(vaccination.getId())
-                .name(vaccination.getName())
-                .year(vaccination.getTimeYear())
-                .month(vaccination.getTimeMonth())
-                .day(vaccination.getTimeDay())
-                .build();
+        return new OneVaccinationResponse(
+                vaccination.getId(),
+                vaccination.getName(),
+                vaccination.getVaccinatedAt().getYear(),
+                vaccination.getVaccinatedAt().getMonthValue(),
+                vaccination.getVaccinatedAt().getDayOfMonth()
+        );
     }
 }

--- a/src/main/java/com/kau/capstone/domain/vaccination/dto/PetVaccinationResponse.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/dto/PetVaccinationResponse.java
@@ -1,16 +1,12 @@
 package com.kau.capstone.domain.vaccination.dto;
 
 import com.kau.capstone.domain.pet.entity.Pet;
-import lombok.Builder;
 
-@Builder
 public record PetVaccinationResponse(
         String name
 ) {
 
     public static PetVaccinationResponse toResponse(Pet pet) {
-        return PetVaccinationResponse.builder()
-                .name(pet.getName())
-                .build();
+        return new PetVaccinationResponse(pet.getName());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/vaccination/dto/VaccinationsResponse.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/dto/VaccinationsResponse.java
@@ -2,11 +2,9 @@ package com.kau.capstone.domain.vaccination.dto;
 
 import com.kau.capstone.domain.pet.entity.Pet;
 import com.kau.capstone.domain.vaccination.entity.Vaccination;
-import lombok.Builder;
 
 import java.util.List;
 
-@Builder
 public record VaccinationsResponse(
         PetVaccinationResponse pet,
         List<OneVaccinationResponse> vaccination
@@ -18,9 +16,6 @@ public record VaccinationsResponse(
                 .map(OneVaccinationResponse::toResponse)
                 .toList();
 
-        return VaccinationsResponse.builder()
-                .pet(petResponse)
-                .vaccination(vaccinationResponses)
-                .build();
+        return new VaccinationsResponse(petResponse, vaccinationResponses);
     }
 }

--- a/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
@@ -37,7 +37,7 @@ public class Vaccination {
     @JoinColumn(name = "pet_id")
     private Pet pet;
 
-    @Comment("예바접종 이름")
+    @Comment("예방접종 이름")
     private String name;
 
     @Comment("연도")

--- a/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
@@ -15,6 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
@@ -40,14 +42,10 @@ public class Vaccination {
     @Comment("예방접종 이름")
     private String name;
 
-    @Comment("연도")
-    private Integer timeYear;
+    @Comment("접종시기")
+    private LocalDate vaccinatedAt;
 
-    @Comment("월")
-    private Integer timeMonth;
 
-    @Comment("일")
-    private Integer timeDay;
 
     public void modify(String name, Integer year, Integer month, Integer day) {
         this.name = name;

--- a/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/entity/Vaccination.java
@@ -2,6 +2,8 @@ package com.kau.capstone.domain.vaccination.entity;
 
 import com.kau.capstone.domain.member.entity.Member;
 import com.kau.capstone.domain.pet.entity.Pet;
+import com.kau.capstone.domain.vaccination.dto.CreateVaccinationRequest;
+import com.kau.capstone.domain.vaccination.dto.PutVaccinationRequest;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,8 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -19,8 +19,6 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Vaccination {
 
@@ -45,12 +43,24 @@ public class Vaccination {
     @Comment("접종시기")
     private LocalDate vaccinatedAt;
 
-
-
-    public void modify(String name, Integer year, Integer month, Integer day) {
+    private Vaccination(Member member, Pet pet, String name, LocalDate vaccinatedAt) {
+        this.member = member;
+        this.pet = pet;
         this.name = name;
-        this.timeYear = year;
-        this.timeMonth = month;
-        this.timeDay = day;
+        this.vaccinatedAt = vaccinatedAt;
+    }
+
+    public static Vaccination of(Member member, Pet pet, CreateVaccinationRequest request) {
+        return new Vaccination(
+                member,
+                pet,
+                request.name(),
+                LocalDate.of(request.year(), request.month(), request.day())
+        );
+    }
+
+    public void modify(PutVaccinationRequest request) {
+        this.name = request.name();
+        this.vaccinatedAt = LocalDate.of(request.year(), request.month(), request.day());
     }
 }

--- a/src/main/java/com/kau/capstone/domain/vaccination/repository/VaccinationRepository.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/repository/VaccinationRepository.java
@@ -1,6 +1,5 @@
 package com.kau.capstone.domain.vaccination.repository;
 
-import com.kau.capstone.domain.member.entity.Member;
 import com.kau.capstone.domain.pet.entity.Pet;
 import com.kau.capstone.domain.vaccination.entity.Vaccination;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +10,6 @@ import java.util.List;
 
 public interface VaccinationRepository extends JpaRepository<Vaccination, Long> {
 
-    @Query("SELECT v FROM Vaccination v WHERE v.pet = :pet ORDER BY v.timeYear DESC, v.timeMonth DESC, v.timeDay DESC")
+    @Query("SELECT v FROM Vaccination v WHERE v.pet = :pet ORDER BY v.vaccinatedAt DESC")
     List<Vaccination> findAllByMemberAndPet(@Param("pet") Pet pet);
 }

--- a/src/main/java/com/kau/capstone/domain/vaccination/service/VaccinationService.java
+++ b/src/main/java/com/kau/capstone/domain/vaccination/service/VaccinationService.java
@@ -47,14 +47,7 @@ public class VaccinationService {
         Pet pet = petRepository.findById(petId)
                 .orElseThrow(() -> new PetNotFoundException(PET_INFO_NOT_FOUND));
 
-        Vaccination vaccination = Vaccination.builder()
-                .member(member)
-                .pet(pet)
-                .name(request.name())
-                .timeYear(request.year())
-                .timeMonth(request.month())
-                .timeDay(request.day())
-                .build();
+        Vaccination vaccination = Vaccination.of(member, pet, request);
         vaccinationRepository.save(vaccination);
     }
 
@@ -62,7 +55,7 @@ public class VaccinationService {
         Vaccination vaccination = vaccinationRepository.findById(vaccinationId)
                 .orElseThrow(() -> new VaccinationNotFoundException(VACCINATION_NOT_FOUND));
 
-        vaccination.modify(request.name(), request.year(), request.month(), request.day());
+        vaccination.modify(request);
     }
 
     public void deleteVaccinationInfo(Long vaccinationId) {

--- a/src/test/java/com/kau/capstone/domain/vaccination/controller/VaccinationControllerTest.java
+++ b/src/test/java/com/kau/capstone/domain/vaccination/controller/VaccinationControllerTest.java
@@ -10,7 +10,6 @@ import com.kau.capstone.global.common.ControllerTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -80,14 +78,7 @@ class VaccinationControllerTest extends ControllerTest {
                     .build();
             petRepository.save(pet);
 
-            Vaccination vaccination = Vaccination.builder()
-                    .member(member)
-                    .pet(pet)
-                    .name("광견병")
-                    .timeYear(2024)
-                    .timeMonth(10)
-                    .timeDay(16)
-                    .build();
+            Vaccination vaccination = Vaccination.of(member, pet, new CreateVaccinationRequest("광견병", 2024, 10, 16));
             vaccinationRepository.save(vaccination);
 
             // when
@@ -130,14 +121,7 @@ class VaccinationControllerTest extends ControllerTest {
                     .build();
             petRepository.save(pet);
 
-            Vaccination vaccination = Vaccination.builder()
-                    .member(member)
-                    .pet(pet)
-                    .name("광견병")
-                    .timeYear(2024)
-                    .timeMonth(10)
-                    .timeDay(16)
-                    .build();
+            Vaccination vaccination = Vaccination.of(member, pet, new CreateVaccinationRequest("광견병", 2024, 10, 16));
             vaccinationRepository.save(vaccination);
 
             PutVaccinationRequest request = new PutVaccinationRequest("켄넬코프", 2025, 11, 17);
@@ -177,14 +161,7 @@ class VaccinationControllerTest extends ControllerTest {
                     .build();
             petRepository.save(pet);
 
-            Vaccination vaccination = Vaccination.builder()
-                    .member(member)
-                    .pet(pet)
-                    .name("광견병")
-                    .timeYear(2024)
-                    .timeMonth(10)
-                    .timeDay(16)
-                    .build();
+            Vaccination vaccination = Vaccination.of(member, pet, new CreateVaccinationRequest("광견병", 2024, 10, 16));
             vaccinationRepository.save(vaccination);
 
             // when


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #216 


## 📝작업 내용

- Vaccination 엔티티의 year, month, day 각각의 컬럼을 vaccinatedAt 으로 통합
  - 관련 내용 기존 DTO에 맞게 조정
- 기존 생성자 형태 변경 및 빌더 패턴 제거

